### PR TITLE
Added missing props defaultTitle

### DIFF
--- a/src/meta/defaultSEO.tsx
+++ b/src/meta/defaultSEO.tsx
@@ -9,6 +9,7 @@ export default class extends Component<DefaultSeoProps, {}> {
     const {
       title,
       titleTemplate,
+      defaultTitle,
       dangerouslySetAllPagesToNoIndex = false,
       dangerouslySetAllPagesToNoFollow = false,
       description,
@@ -30,6 +31,7 @@ export default class extends Component<DefaultSeoProps, {}> {
         {buildTags({
           title,
           titleTemplate,
+          defaultTitle,
           dangerouslySetAllPagesToNoIndex,
           dangerouslySetAllPagesToNoFollow,
           description,


### PR DESCRIPTION
defaultTitle was not working because it was not decustructed from DefaultSeoProps and pass to buildTags function.

## Description of Change(s):

---

Some things to help get a PR reviewed and merged faster:

- Have you updated the documentation to go with your changes?
- Have you written or updated unit tests?
- Have you written an integration test in the test app supplied?

The above are generally required on all PR's.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
